### PR TITLE
Fix image thumbnails and integrate Sheets API

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,9 +18,7 @@ const data = {
       description: "A beautiful depiction of Indiana's covered bridge heritage",
       artistBio: "Alyson Hatcher-Kendall is a talented artist whose work captures the historic charm of Indiana's architectural heritage.",
       auctionEnd: "2025-08-15T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Alyson-Hatcher-Kendall-scaled-e1725475040768-1024x1018.jpg"
     },
     {
@@ -36,9 +34,7 @@ const data = {
       description: "Vibrant autumn colors captured in layered brushstrokes",
       artistBio: "Dajanell Johnson creates dynamic works that celebrate the natural beauty of seasonal transitions.",
       auctionEnd: "2025-08-16T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Dajanell-Johnson-747x1024.jpg"
     },
     {
@@ -54,9 +50,7 @@ const data = {
       description: "A powerful statement piece exploring themes of justice",
       artistBio: "Deb Edwards is known for her thought-provoking artwork that addresses social and moral themes.",
       auctionEnd: "2025-08-17T18:00:00",
-      bidHistory: [
-        { amount: 400, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Deb-Edwards-580x1024.jpg"
     },
     {
@@ -72,9 +66,7 @@ const data = {
       description: "Whimsical textile art bringing fantasy to life",
       artistBio: "Lana Kirtley specializes in mixed media textile art that creates magical, otherworldly scenes.",
       auctionEnd: "2025-08-18T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Lana-Kirtley-1024x1000.jpg"
     },
     {
@@ -90,9 +82,7 @@ const data = {
       description: "Joyful mixed media piece celebrating color and creativity",
       artistBio: "Jaetta Hall creates vibrant mixed media works that celebrate joy and the power of color.",
       auctionEnd: "2025-08-19T18:00:00",
-      bidHistory: [
-        { amount: 160, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Jaetta-Hall-768x1024.jpg"
     },
     {
@@ -108,9 +98,7 @@ const data = {
       description: "Contemporary digital art exploring technology and patriotism",
       artistBio: "Patrick Redmon is a contemporary artist exploring the intersection of technology and traditional artistic expression.",
       auctionEnd: "2025-08-20T18:00:00",
-      bidHistory: [
-        { amount: 800, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Patrick-Redmon-854x1024.jpg"
     },
     {
@@ -126,9 +114,7 @@ const data = {
       description: "Luminous botanical artwork celebrating growth and light",
       artistBio: "Mia Flowers creates botanical art that captures the luminous quality of plant life and natural growth.",
       auctionEnd: "2025-08-21T18:00:00",
-      bidHistory: [
-        { amount: 275, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Mia-Flowers-743x1024.jpg"
     },
     {
@@ -144,9 +130,7 @@ const data = {
       description: "Emotionally powerful piece exploring themes of resilience",
       artistBio: "Ramona \"Mona\" Daniels creates emotionally resonant artwork that explores human resilience and strength.",
       auctionEnd: "2025-08-22T18:00:00",
-      bidHistory: [
-        { amount: 715, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Ramona-Mona-Daniels-616x1024.jpg"
     },
     {
@@ -162,9 +146,7 @@ const data = {
       description: "Introspective artwork exploring inner vision and perception",
       artistBio: "Sam Prifogle creates introspective artwork that invites viewers to explore themes of consciousness and perception.",
       auctionEnd: "2025-08-23T18:00:00",
-      bidHistory: [
-        { amount: 500, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Sam-Prifogle-832x1024.jpg"
     },
     {
@@ -180,9 +162,7 @@ const data = {
       description: "Large-scale floral tribute to the Kokomo community",
       artistBio: "Oscar Toloza creates large-scale works that celebrate community and the beauty of local landmarks.",
       auctionEnd: "2025-08-24T18:00:00",
-      bidHistory: [
-        { amount: 600, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Oscar-Toloza-930x1024.jpg"
     },
     {
@@ -198,9 +178,7 @@ const data = {
       description: "Bold spray paint artwork capturing the beauty of wild nature",
       artistBio: "Michelle Sutton is a contemporary artist who uses spray paint to create bold, dynamic works celebrating natural beauty.",
       auctionEnd: "2025-08-25T18:00:00",
-      bidHistory: [
-        { amount: 3000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Michelle-Sutton-scaled.jpg"
     },
     {
@@ -216,9 +194,7 @@ const data = {
       description: "Mixed media portrait celebrating feminine strength",
       artistBio: "Tarja Harney creates powerful mixed media portraits that celebrate strength and resilience.",
       auctionEnd: "2025-08-26T18:00:00",
-      bidHistory: [
-        { amount: 200, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Tarja-Harney-1024x928.jpg"
     },
     {
@@ -234,9 +210,7 @@ const data = {
       description: "Delicate botanical study showcasing Indiana's native flora",
       artistBio: "Rose Bloom specializes in botanical art that captures the delicate beauty of Indiana's native plant life.",
       auctionEnd: "2025-08-27T18:00:00",
-      bidHistory: [
-        { amount: 1000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Rose-Bloom-756x1024.jpg"
     },
     {
@@ -252,9 +226,7 @@ const data = {
       description: "Symbolic artwork representing growth and optimism",
       artistBio: "Lesley Wysong serves as the Art Center Curator for the Kokomo Art Association and creates symbolic works exploring themes of hope and growth.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 450, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Lesley-Wysong-639x1024.jpg"
     },
     {
@@ -270,9 +242,7 @@ const data = {
       description: "Mysterious mixed media piece exploring cosmic themes",
       artistBio: "Marcia Blacklidge creates mysterious mixed media works that explore cosmic and metaphysical themes.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 500, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Marcia-Blacklidge-702x1024.jpg"
     },
     {
@@ -288,9 +258,7 @@ const data = {
       description: "Monumental granite sculpture offering hope and connection",
       artistBio: "Troy Caldwell is a sculptor who works in granite to create monumental pieces that offer messages of hope and connection.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 3000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Troy-Caldwell-Scaled-1024x454.jpg"
     }
   ],
@@ -314,6 +282,18 @@ const data = {
 let currentSection = 'home';
 let selectedArtworkId = null;
 let pendingBid = null;
+let currentUser = null;
+
+// Google API configuration (replace placeholders with real values)
+const CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';
+const API_KEY = 'YOUR_GOOGLE_API_KEY';
+const SHEET_ID = 'YOUR_SHEET_ID';
+const DISCOVERY_DOC = 'https://sheets.googleapis.com/$discovery/rest?version=v4';
+const SCOPES = 'https://www.googleapis.com/auth/spreadsheets';
+
+let tokenClient;
+let gapiInited = false;
+let gisInited = false;
 
 /* ==============================
    Utilities
@@ -323,6 +303,10 @@ const $$ = (selector, scope = document) => Array.from(scope.querySelectorAll(sel
 
 function formatCurrency(num) {
   return `$${num.toLocaleString()}`;
+}
+
+function bidLabel(art) {
+  return art.bidHistory && art.bidHistory.length > 0 ? 'Current Bid' : 'Starting Bid';
 }
 
 function formatDateTime(dateStr) {
@@ -414,7 +398,7 @@ function createArtworkCard(art) {
         <p class="artwork-medium">${art.medium} • ${art.dimensions}</p>
         <div class="artwork-bidding">
           <div class="current-bid">
-            <span>Current Bid</span>
+            <span>${bidLabel(art)}</span>
             <span class="bid-amount">${formatCurrency(art.currentBid)}</span>
           </div>
           <span class="auction-status ${auctionStatusClass(art)}">${auctionStatusLabel(art)}</span>
@@ -525,7 +509,7 @@ function openArtworkDetail(id) {
 
       <div class="bidding-section">
         <div class="current-bid">
-          <span>Current Bid</span>
+          <span>${bidLabel(art)}</span>
           <span class="bid-amount" id="detail-current-bid">${formatCurrency(art.currentBid)}</span>
         </div>
         <div class="auction-status ${auctionStatusClass(art)}" id="detail-status">${auctionStatusLabel(art)}</div>
@@ -601,6 +585,9 @@ function generateIncrementButtons(art) {
 }
 
 function renderBidHistory(history) {
+  if (!history || history.length === 0) {
+    return '<p>No bids yet.</p>';
+  }
   return history
     .slice()
     .reverse()
@@ -630,15 +617,22 @@ function closeBidModal() {
 
 function confirmBid() {
   if (!pendingBid) return;
+  if (gapi.client.getToken() === null) {
+    alert('Please sign in to place a bid.');
+    return;
+  }
+
   const art = data.artworks.find((a) => a.id === pendingBid.id);
   if (!art) return;
-  
+
   art.currentBid = pendingBid.amount;
   art.bidHistory.push({
     amount: pendingBid.amount,
-    bidder: 'You',
+    bidder: currentUser || 'You',
     time: new Date().toISOString()
   });
+
+  appendBidToSheet(art, pendingBid.amount);
   
   closeBidModal();
   
@@ -652,6 +646,87 @@ function confirmBid() {
 // Make modal functions globally available
 window.closeBidModal = closeBidModal;
 window.confirmBid = confirmBid;
+window.handleAuthClick = handleAuthClick;
+window.handleSignOutClick = handleSignOutClick;
+window.gapiLoaded = gapiLoaded;
+window.gisLoaded = gisLoaded;
+
+/* ==============================
+   Google Sheets Integration
+============================== */
+function gapiLoaded() {
+  gapi.load('client', initializeGapiClient);
+}
+
+async function initializeGapiClient() {
+  await gapi.client.init({
+    apiKey: API_KEY,
+    discoveryDocs: [DISCOVERY_DOC]
+  });
+  gapiInited = true;
+  maybeEnableAuth();
+}
+
+function gisLoaded() {
+  tokenClient = google.accounts.oauth2.initTokenClient({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+    callback: ''
+  });
+  gisInited = true;
+  maybeEnableAuth();
+}
+
+function maybeEnableAuth() {
+  if (gapiInited && gisInited) {
+    const btn = $('#signin-button');
+    if (btn) btn.style.display = 'inline-block';
+  }
+}
+
+function handleAuthClick() {
+  tokenClient.callback = async (resp) => {
+    if (resp.error !== undefined) {
+      console.error(resp);
+      return;
+    }
+    currentUser = 'Authenticated';
+    $('#signout-button').style.display = 'inline-block';
+    $('#signin-button').style.display = 'none';
+  };
+
+  if (gapi.client.getToken() === null) {
+    tokenClient.requestAccessToken({ prompt: 'consent' });
+  } else {
+    tokenClient.requestAccessToken({ prompt: '' });
+  }
+}
+
+function handleSignOutClick() {
+  const token = gapi.client.getToken();
+  if (token !== null) {
+    google.accounts.oauth2.revoke(token.access_token);
+    gapi.client.setToken('');
+    currentUser = null;
+    $('#signout-button').style.display = 'none';
+    $('#signin-button').style.display = 'inline-block';
+  }
+}
+
+async function appendBidToSheet(art, amount) {
+  if (!gapiInited) return;
+  const values = [[new Date().toISOString(), art.id, art.title, amount]];
+  try {
+    await gapi.client.sheets.spreadsheets.values.append({
+      spreadsheetId: SHEET_ID,
+      range: 'Bids!A:D',
+      valueInputOption: 'USER_ENTERED',
+      resource: { values }
+    });
+  } catch (err) {
+    console.error('Failed to log bid', err);
+  }
+}
 
 /* ==============================
    Countdown Timers

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
                     <li><a href="#" class="nav-link" data-section="about">About Artist Alley</a></li>
                     <li><a href="#" class="nav-link" data-section="contact">Contact</a></li>
                 </ul>
+                <div class="nav-auth">
+                    <button id="signin-button" class="btn btn--secondary" style="display:none" onclick="handleAuthClick()">Sign In</button>
+                    <button id="signout-button" class="btn btn--secondary" style="display:none" onclick="handleSignOutClick()">Sign Out</button>
+                </div>
             </div>
         </div>
     </nav>
@@ -186,5 +190,7 @@
     </div>
 
     <script src="app.js"></script>
+    <script src="https://apis.google.com/js/api.js?onload=gapiLoaded" async defer></script>
+    <script src="https://accounts.google.com/gsi/client" onload="gisLoaded()" async defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -726,6 +726,11 @@ select.form-control {
   gap: var(--space-24);
 }
 
+.nav-auth {
+  display: flex;
+  gap: var(--space-8);
+}
+
 .nav-link {
   color: var(--color-text);
   font-weight: var(--font-weight-medium);
@@ -877,6 +882,13 @@ select.form-control {
   overflow: hidden;
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-medium);
+}
+
+.artwork-image img,
+.artwork-detail-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .artwork-image::before {


### PR DESCRIPTION
## Summary
- show full artwork images in thumbnails and detail views
- remove seeded bids and update bid history UI when empty
- show `Starting Bid` label when no bids are placed
- add Google Sign In and Sheets API integration for saving bids

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68777ebe006883288af9ac4ecc1c6773