### PR TITLE
Enhance bidding flow and add email notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,9 +26,7 @@ const data = {
       description: "A beautiful depiction of Indiana's covered bridge heritage",
       artistBio: "Alyson Hatcher-Kendall is a talented artist whose work captures the historic charm of Indiana's architectural heritage.",
       auctionEnd: "2025-08-15T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Alyson-Hatcher-Kendall-scaled-e1725475040768-1024x1018.jpg"
     },
     {
@@ -44,9 +42,7 @@ const data = {
       description: "Vibrant autumn colors captured in layered brushstrokes",
       artistBio: "Dajanell Johnson creates dynamic works that celebrate the natural beauty of seasonal transitions.",
       auctionEnd: "2025-08-16T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Dajanell-Johnson-747x1024.jpg"
     },
     {
@@ -62,9 +58,7 @@ const data = {
       description: "A powerful statement piece exploring themes of justice",
       artistBio: "Deb Edwards is known for her thought-provoking artwork that addresses social and moral themes.",
       auctionEnd: "2025-08-17T18:00:00",
-      bidHistory: [
-        { amount: 400, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Deb-Edwards-580x1024.jpg"
     },
     {
@@ -80,9 +74,7 @@ const data = {
       description: "Whimsical textile art bringing fantasy to life",
       artistBio: "Lana Kirtley specializes in mixed media textile art that creates magical, otherworldly scenes.",
       auctionEnd: "2025-08-18T18:00:00",
-      bidHistory: [
-        { amount: 300, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Lana-Kirtley-1024x1000.jpg"
     },
     {
@@ -98,9 +90,7 @@ const data = {
       description: "Joyful mixed media piece celebrating color and creativity",
       artistBio: "Jaetta Hall creates vibrant mixed media works that celebrate joy and the power of color.",
       auctionEnd: "2025-08-19T18:00:00",
-      bidHistory: [
-        { amount: 160, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Jaetta-Hall-768x1024.jpg"
     },
     {
@@ -116,9 +106,7 @@ const data = {
       description: "Contemporary digital art exploring technology and patriotism",
       artistBio: "Patrick Redmon is a contemporary artist exploring the intersection of technology and traditional artistic expression.",
       auctionEnd: "2025-08-20T18:00:00",
-      bidHistory: [
-        { amount: 800, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Patrick-Redmon-854x1024.jpg"
     },
     {
@@ -134,9 +122,7 @@ const data = {
       description: "Luminous botanical artwork celebrating growth and light",
       artistBio: "Mia Flowers creates botanical art that captures the luminous quality of plant life and natural growth.",
       auctionEnd: "2025-08-21T18:00:00",
-      bidHistory: [
-        { amount: 275, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Mia-Flowers-743x1024.jpg"
     },
     {
@@ -152,9 +138,7 @@ const data = {
       description: "Emotionally powerful piece exploring themes of resilience",
       artistBio: "Ramona \"Mona\" Daniels creates emotionally resonant artwork that explores human resilience and strength.",
       auctionEnd: "2025-08-22T18:00:00",
-      bidHistory: [
-        { amount: 715, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Ramona-Mona-Daniels-616x1024.jpg"
     },
     {
@@ -170,9 +154,7 @@ const data = {
       description: "Introspective artwork exploring inner vision and perception",
       artistBio: "Sam Prifogle creates introspective artwork that invites viewers to explore themes of consciousness and perception.",
       auctionEnd: "2025-08-23T18:00:00",
-      bidHistory: [
-        { amount: 500, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Sam-Prifogle-832x1024.jpg"
     },
     {
@@ -188,9 +170,7 @@ const data = {
       description: "Large-scale floral tribute to the Kokomo community",
       artistBio: "Oscar Toloza creates large-scale works that celebrate community and the beauty of local landmarks.",
       auctionEnd: "2025-08-24T18:00:00",
-      bidHistory: [
-        { amount: 600, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Oscar-Toloza-930x1024.jpg"
     },
     {
@@ -206,9 +186,7 @@ const data = {
       description: "Bold spray paint artwork capturing the beauty of wild nature",
       artistBio: "Michelle Sutton is a contemporary artist who uses spray paint to create bold, dynamic works celebrating natural beauty.",
       auctionEnd: "2025-08-25T18:00:00",
-      bidHistory: [
-        { amount: 3000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Michelle-Sutton-scaled.jpg"
     },
     {
@@ -224,9 +202,7 @@ const data = {
       description: "Mixed media portrait celebrating feminine strength",
       artistBio: "Tarja Harney creates powerful mixed media portraits that celebrate strength and resilience.",
       auctionEnd: "2025-08-26T18:00:00",
-      bidHistory: [
-        { amount: 200, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Tarja-Harney-1024x928.jpg"
     },
     {
@@ -242,9 +218,7 @@ const data = {
       description: "Delicate botanical study showcasing Indiana's native flora",
       artistBio: "Rose Bloom specializes in botanical art that captures the delicate beauty of Indiana's native plant life.",
       auctionEnd: "2025-08-27T18:00:00",
-      bidHistory: [
-        { amount: 1000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Rose-Bloom-756x1024.jpg"
     },
     {
@@ -260,9 +234,7 @@ const data = {
       description: "Symbolic artwork representing growth and optimism",
       artistBio: "Lesley Wysong serves as the Art Center Curator for the Kokomo Art Association and creates symbolic works exploring themes of hope and growth.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 450, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Lesley-Wysong-639x1024.jpg"
     },
     {
@@ -278,9 +250,7 @@ const data = {
       description: "Mysterious mixed media piece exploring cosmic themes",
       artistBio: "Marcia Blacklidge creates mysterious mixed media works that explore cosmic and metaphysical themes.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 500, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Marcia-Blacklidge-702x1024.jpg"
     },
     {
@@ -296,9 +266,7 @@ const data = {
       description: "Monumental granite sculpture offering hope and connection",
       artistBio: "Troy Caldwell is a sculptor who works in granite to create monumental pieces that offer messages of hope and connection.",
       auctionEnd: "2025-08-28T18:00:00",
-      bidHistory: [
-        { amount: 3000, bidder: "Anonymous", time: "2025-07-16T08:00:00" }
-      ],
+      bidHistory: [],
       image: "assets/Troy-Caldwell-Scaled-1024x454.jpg"
     }
   ],
@@ -428,17 +396,6 @@ window.showSection = showSection;
 /* ==============================
    Rendering Functions
 ============================== */
-function renderFeatured() {
-  const container = $('#featured-grid');
-  if (!container) return;
-
-  container.innerHTML = '';
-  // Select first 3 artworks as featured
-  data.artworks.slice(0, 3).forEach((art) => {
-    const card = createArtworkCard(art);
-    container.appendChild(card);
-  });
-}
 
 function createArtworkCard(art) {
   const card = document.createElement('div');
@@ -572,7 +529,7 @@ function openArtworkDetail(id) {
         <div class="auction-status ${auctionStatusClass(art)}" id="detail-status">${auctionStatusLabel(art)}</div>
         <div class="time-remaining" id="detail-timer" data-end="${art.auctionEnd}"></div>
         <div class="bid-controls" id="bid-controls">
-          ${generateIncrementButtons(art)}
+          ${art.bidHistory.length === 0 ? `<button class="btn btn--primary" id="start-bid-btn">Bid ${formatCurrency(art.startingBid)}</button>` : generateIncrementButtons(art)}
         </div>
         <p id="selected-increment" class="mt-8"></p>
       </div>
@@ -590,38 +547,40 @@ function openArtworkDetail(id) {
     </div>
   `;
 
-  // Setup increment selection
-  let chosenIncrement = null;
-  $$('#bid-controls .bid-increment', container).forEach((btn) => {
-    btn.addEventListener('click', () => {
-      // Remove active class from all buttons
-      $$('#bid-controls .bid-increment', container).forEach(b => b.classList.remove('active'));
-      
-      // Add active class to clicked button
-      btn.classList.add('active');
-      
-      const inc = parseInt(btn.dataset.increment, 10);
-      chosenIncrement = inc;
-      const newBid = art.currentBid + inc;
-      $('#selected-increment', container).textContent = `Next bid: ${formatCurrency(newBid)}`;
-      
-      // Create or update place bid button
-      let placeBidBtn = $('#place-bid-btn', container);
-      if (!placeBidBtn) {
-        placeBidBtn = document.createElement('button');
-        placeBidBtn.id = 'place-bid-btn';
-        placeBidBtn.className = 'btn btn--primary';
-        placeBidBtn.textContent = 'Place Bid';
-        $('#bid-controls', container).appendChild(placeBidBtn);
-      }
-      
-      placeBidBtn.onclick = () => {
-        pendingBid = { id: art.id, amount: newBid };
-        $('#bid-confirmation-text').textContent = `You are about to place a bid of ${formatCurrency(newBid)} on "${art.title}".`;
-        openBidModal();
-      };
+  // Setup bid controls
+  const startBtn = $('#start-bid-btn', container);
+  if (startBtn) {
+    startBtn.addEventListener('click', () => {
+      pendingBid = { id: art.id, amount: art.startingBid };
+      $('#bid-confirmation-text').textContent = `You are about to place a starting bid of ${formatCurrency(art.startingBid)} on "${art.title}".`;
+      openBidModal();
     });
-  });
+  } else {
+    let chosenIncrement = null;
+    $$('#bid-controls .bid-increment', container).forEach((btn) => {
+      btn.addEventListener('click', () => {
+        $$('#bid-controls .bid-increment', container).forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const inc = parseInt(btn.dataset.increment, 10);
+        chosenIncrement = inc;
+        const newBid = art.currentBid + inc;
+        $('#selected-increment', container).textContent = `Next bid: ${formatCurrency(newBid)}`;
+        let placeBidBtn = $('#place-bid-btn', container);
+        if (!placeBidBtn) {
+          placeBidBtn = document.createElement('button');
+          placeBidBtn.id = 'place-bid-btn';
+          placeBidBtn.className = 'btn btn--primary';
+          placeBidBtn.textContent = 'Place Bid';
+          $('#bid-controls', container).appendChild(placeBidBtn);
+        }
+        placeBidBtn.onclick = () => {
+          pendingBid = { id: art.id, amount: newBid };
+          $('#bid-confirmation-text').textContent = `You are about to place a bid of ${formatCurrency(newBid)} on "${art.title}".`;
+          openBidModal();
+        };
+      });
+    });
+  }
 
   // Disable controls if auction ended
   const { total } = getTimeRemaining(art.auctionEnd);
@@ -658,6 +617,10 @@ function openBidModal() {
   const bidModal = $('#bid-modal');
   if (bidModal) {
     bidModal.classList.add('active');
+    const emailInput = $('#bidder-email');
+    if (emailInput) {
+      emailInput.value = localStorage.getItem('bidderEmail') || '';
+    }
   }
 }
 
@@ -683,6 +646,12 @@ function confirmBid() {
 
   saveBidData();
 
+  const emailInput = $('#bidder-email');
+  const email = emailInput ? emailInput.value.trim() : '';
+  if (email) {
+    localStorage.setItem('bidderEmail', email);
+  }
+
   // Send the bid to the server
   try {
     fetch('/bid', {
@@ -694,6 +663,7 @@ function confirmBid() {
         artworkId: art.id,
         amount: pendingBid.amount,
         bidder: 'You',
+        email,
       }),
     });
   } catch (err) {
@@ -759,7 +729,6 @@ function init() {
   }
 
   // Render initial content
-  renderFeatured();
   renderGallery();
   
   // Start timers

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kokomo Artist Alley - Online Art Auction</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
     <nav class="navbar">
@@ -15,11 +16,11 @@
                     <span class="brand-subtitle">Online Art Auction</span>
                 </div>
                 <ul class="nav-menu">
-                    <li><a href="#" class="nav-link active" data-section="home">Home</a></li>
-                    <li><a href="#" class="nav-link" data-section="auctions">Current Auctions</a></li>
-                    <li><a href="#" class="nav-link" data-section="how-to-bid">How to Bid</a></li>
-                    <li><a href="#" class="nav-link" data-section="about">About Artist Alley</a></li>
-                    <li><a href="#" class="nav-link" data-section="contact">Contact</a></li>
+                    <li><a href="#" class="nav-link active" data-section="home"><i class="fa-solid fa-home"></i><span class="sr-only">Home</span></a></li>
+                    <li><a href="#" class="nav-link" data-section="auctions"><i class="fa-solid fa-gavel"></i><span class="sr-only">Current Auctions</span></a></li>
+                    <li><a href="#" class="nav-link" data-section="how-to-bid"><i class="fa-solid fa-question-circle"></i><span class="sr-only">How to Bid</span></a></li>
+                    <li><a href="#" class="nav-link" data-section="about"><i class="fa-solid fa-info-circle"></i><span class="sr-only">About Artist Alley</span></a></li>
+                    <li><a href="#" class="nav-link" data-section="contact"><i class="fa-solid fa-envelope"></i><span class="sr-only">Contact</span></a></li>
                 </ul>
             </div>
         </div>
@@ -36,15 +37,6 @@
                         <button class="btn btn--primary btn--lg" onclick="showSection('auctions')">Browse Current Auctions</button>
                     </div>
                 </div>
-            </div>
-
-            <div class="featured-section">
-                <div class="container">
-                    <h2 class="section-title">Featured Artist Alley Artworks</h2>
-                    <div class="featured-grid" id="featured-grid">
-                        </div>
-                </div>
-            </div>
         </section>
 
         <section id="auctions" class="section">
@@ -178,6 +170,7 @@
         <div class="modal-content">
             <h3>Confirm Your Bid</h3>
             <p id="bid-confirmation-text"></p>
+            <input type="email" id="bidder-email" class="form-control" placeholder="Your email">
             <div class="modal-actions">
                 <button class="btn btn--secondary" onclick="closeBidModal()">Cancel</button>
                 <button class="btn btn--primary" onclick="confirmBid()">Confirm Bid</button>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "express": "^5.1.0",
-    "googleapis": "^153.0.0"
+    "googleapis": "^153.0.0",
+    "nodemailer": "^6.9.11"
   },
   "scripts": {
     "start": "node server.js"

--- a/server.js
+++ b/server.js
@@ -1,8 +1,33 @@
 const express = require('express');
 const { google } = require('googleapis');
+const nodemailer = require('nodemailer');
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+const thankYouMessages = [
+  'Thank you for placing a bid!',
+  'We appreciate your support of local art!',
+  'Thanks for participating in the auction!'
+];
+
+const outbidMessages = [
+  "Oh no... you've been outbid.",
+  'Oops, someone placed a higher bid.',
+  'Another bidder has topped your offer.'
+];
+
+const highestBids = {};
 
 app.use(express.json());
 
@@ -38,6 +63,36 @@ async function appendBidToSheet(bid) {
   });
 }
 
+async function sendBidEmail(email) {
+  if (!email) return;
+  const msg = thankYouMessages[Math.floor(Math.random() * thankYouMessages.length)];
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: email,
+      subject: 'Bid Received',
+      text: `${msg} Again, we would like to thank you for supporting the community of art here in Kokomo, Indiana.`
+    });
+  } catch (err) {
+    console.error('Email send failed', err);
+  }
+}
+
+async function sendOutbidEmail(email) {
+  if (!email) return;
+  const msg = outbidMessages[Math.floor(Math.random() * outbidMessages.length)];
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: email,
+      subject: 'Outbid Notification',
+      text: msg
+    });
+  } catch (err) {
+    console.error('Email send failed', err);
+  }
+}
+
 const bids = [];
 
 app.get('/bids', (req, res) => {
@@ -45,7 +100,7 @@ app.get('/bids', (req, res) => {
 });
 
 app.post('/bid', async (req, res) => {
-  const { artworkId, amount, bidder } = req.body;
+  const { artworkId, amount, bidder, email } = req.body;
   if (!artworkId || !amount || !bidder) {
     return res.status(400).json({ error: 'Missing required fields' });
   }
@@ -58,6 +113,12 @@ app.post('/bid', async (req, res) => {
   } catch (err) {
     console.error('Error writing to Sheets:', err);
   }
+  const prev = highestBids[artworkId];
+  if (prev && prev.email && amount > prev.amount) {
+    sendOutbidEmail(prev.email);
+  }
+  highestBids[artworkId] = { amount, email };
+  sendBidEmail(email);
 
   res.json({ success: true });
 });

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 
 :root {
   /* Colors */
-  --color-background: rgba(252, 252, 249, 1);
+  --color-background: #e0e0e0;
   --color-surface: rgba(255, 255, 253, 1);
   --color-text: rgba(19, 52, 59, 1);
   --color-text-secondary: rgba(98, 108, 113, 1);
@@ -227,6 +227,7 @@ html {
 }
 
 body {
+  background: radial-gradient(circle at 50% 50%, #f0f0f0 0%, #bbb 100%);
   margin: 0;
   padding: 0;
 }
@@ -466,6 +467,7 @@ select.form-control {
 }
 
 .card__body {
+  background: radial-gradient(circle at 50% 50%, #f0f0f0 0%, #bbb 100%);
   padding: var(--space-16);
 }
 
@@ -865,7 +867,7 @@ select.form-control {
 }
 
 .artwork-image {
-  width: 100%;
+  overflow: hidden;
   height: 240px;
   background: var(--color-secondary);
   display: flex;
@@ -874,21 +876,25 @@ select.form-control {
   color: var(--color-text-secondary);
   font-style: italic;
   position: relative;
-  overflow: hidden;
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-medium);
 }
-
-.artwork-image::before {
-  content: '';
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  right: 10px;
-  bottom: 10px;
-  border: 2px solid var(--color-gallery-frame);
+.artwork-image img,
+.artwork-detail-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s var(--ease-standard), box-shadow 0.3s var(--ease-standard);
+  box-shadow: var(--shadow-sm);
   border-radius: var(--radius-sm);
 }
+
+.artwork-card:hover .artwork-image img,
+.artwork-detail-image:hover img {
+  transform: scale(1.02);
+  box-shadow: var(--shadow-lg);
+}
+
 
 .artwork-info {
   padding: var(--space-16);
@@ -985,16 +991,6 @@ select.form-control {
   font-weight: var(--font-weight-medium);
 }
 
-.artwork-detail-image::before {
-  content: '';
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  right: 20px;
-  bottom: 20px;
-  border: 3px solid var(--color-gallery-frame);
-  border-radius: var(--radius-sm);
-}
 
 .artwork-detail-info {
   display: flex;


### PR DESCRIPTION
## Summary
- drop featured section and nav text links in favor of icon based navigation
- add email field in bid modal and remember it in local storage
- remove artwork frames, add image shadows/animations, update background
- allow bidding to start without increments if no bids yet
- send thank you and outbid emails through Nodemailer

## Testing
- `npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877c48921e08328a3e64f4f68248dae